### PR TITLE
fix(auth/app router): resolve logout redirect flash in production

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -15,6 +15,8 @@
       "purpose": "maskable"
     }
   ],
+  "start_url": "/app/",
+  "scope": "/app/",
   "theme_color": "#338866",
   "background_color": "#338866",
   "display": "standalone"

--- a/src/layout/navigation/sidebar/sidebar.tsx
+++ b/src/layout/navigation/sidebar/sidebar.tsx
@@ -6,7 +6,6 @@ import { useLogoutMutation } from '@/queries/user-queries';
 import { useGetPackListQuery, useGetPackQuery } from '@/queries/pack-queries';
 import { encode, decode } from '@/utils';
 import { SidebarButton } from './sidebar-button';
-import supabase from '@/api/supabase-client';
 import { useGetAuth } from '@/hooks/auth/use-get-auth';
 import { useCheckScreen } from '@/hooks/ui/use-check-screen';
 import { MouseOver } from '@/contexts/mouse-over-context';
@@ -78,12 +77,16 @@ export const Sidebar = ({ showSidebar, onToggle }: SidebarProps) => {
 	}, [location.pathname]);
 
 	const handleLogout = async () => {
-		await supabase.auth.signOut();
+		// handle Google auth cleanup first
 		if (typeof google !== 'undefined') {
 			await google.accounts.id.disableAutoSelect();
 		}
-		logout();
-		navigate('/');
+
+		logout(undefined, {
+			onSuccess: () => {
+				navigate('/login', { replace: true });
+			},
+		});
 	};
 
 	return (

--- a/src/queries/user-queries.ts
+++ b/src/queries/user-queries.ts
@@ -56,14 +56,10 @@ export const useRegisterMutation = (): SimpleMutation<
 export const useLogoutMutation = (): SimpleMutation<void, void> => {
 	const queryClient = useQueryClient();
 	return useMutation({
+		mutationKey: ['logout'],
 		mutationFn: async () => {
-			// Redirect immediately to avoid router state changes
-			window.location.replace('/login');
-
-			// Sign out from Supabase
+			await tidyTrekAPI.post('/auth/logout').then(extractData<void>);
 			await supabase.auth.signOut();
-			// Clear server-side cookies
-			return tidyTrekAPI.post('/auth/logout').then(extractData<void>);
 		},
 		onSuccess: () => {
 			queryClient.clear();

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,6 +1,7 @@
 import { createBrowserRouter, RouterProvider } from 'react-router-dom';
 import { Theme } from '@radix-ui/themes';
 import { useMemo } from 'react';
+import { useIsMutating } from '@tanstack/react-query';
 import { DashboardSkeleton, AuthSkeleton } from '@/components/ui';
 import { publicRoutes } from './public.tsx';
 import { protectedRoutes } from './protected.tsx';
@@ -10,13 +11,18 @@ import { useDelayedLoading } from '@/hooks/ui/use-delayed-loading';
 
 export const AppRouter = () => {
 	const { isLoading, isAuthenticated, settings } = useGetAuth();
+	// useIsMutating returns 1 if key is being mutated (isLoggingOut)
+	const isLoggingOut = useIsMutating({ mutationKey: ['logout'] }) > 0;
 	const showSkeleton = useDelayedLoading(isLoading, 200);
 	const { darkMode, palette } = settings || {};
 	const { currentMode, currentPalette } = useThemeSetter(darkMode, palette);
 
 	const appRouter = useMemo(
-		() => createBrowserRouter(isAuthenticated ? protectedRoutes : publicRoutes),
-		[isAuthenticated],
+		() =>
+			createBrowserRouter(
+				isAuthenticated || isLoggingOut ? protectedRoutes : publicRoutes,
+			),
+		[isAuthenticated, isLoggingOut],
 	);
 
 	if (isLoading) {


### PR DESCRIPTION
# Pull Request

## Summary
- Add mutation key to useLogoutMutation
  - Use useIsMutating in router to prevent route switching during logout
  - Move navigation logic to component level using React Router
  - Fix manifest.json scope for /app deployment path

## Type of Change
- [x] Bug fix

## Testing
- [x] Tested locally
- [x] No breaking changes